### PR TITLE
Do not use deprecated `set-output` command

### DIFF
--- a/container/scripts/release.sh
+++ b/container/scripts/release.sh
@@ -20,6 +20,6 @@ fi
 # Push for all container tags
 docker push --all-tags ghcr.io/${PACKAGE_NAME}
 
-echo "::set-output name=container::${PACKAGE_NAME}"
-echo "::set-output name=tag::${INPUT_TAG}"
-echo "::set-output name=commit::${GITHUB_SHA}"
+echo "container=${PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
+echo "tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
+echo "commit=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"

--- a/envpackage/scripts/build.sh
+++ b/envpackage/scripts/build.sh
@@ -55,8 +55,8 @@ tree ${build_cache}
 # We want to save the .json files for any following step :)
 spec_jsons=""
 
-echo "::set-output name=build_cache::${build_cache}"
-echo "::set-output name=build_cache_prefix::${build_cache_prefix}"
+echo "build_cache=${build_cache}" >> "${GITHUB_OUTPUT}"
+echo "build_cache_prefix=${build_cache_prefix}" >> "${GITHUB_OUTPUT}"
 
 # There can be more than one thing in the build cache
 for spec_json in $(find ${build_cache} -name *.json); do
@@ -70,8 +70,8 @@ for spec_json in $(find ${build_cache} -name *.json); do
 done
 
 # Set output for spec, and TODO binary to upload/save for next step
-echo "::set-output name=spec::${SPACK_SPEC}"
-echo "::set-output name=spec_jsons::${spec_jsons}"
+echo "spec=${SPACK_SPEC}" >> "${GITHUB_OUTPUT}"
+echo "spec_jsons=${spec_jsons}" >> "${GITHUB_OUTPUT}"
 echo "spec=${SPACK_SPEC}" >> $GITHUB_ENV
 echo "spec_jsons=${spec_jsons}" >> $GITHUB_ENV
 echo "build_cache=${build_cache}" >> $GITHUB_ENV

--- a/envpackage/scripts/release.sh
+++ b/envpackage/scripts/release.sh
@@ -34,11 +34,11 @@ fi
 
 # Package content type is always consistent
 package_content_type=application/vnd.spack.package
-echo "::set-output name=package_content_type::${package_content_type}"
+echo "package_content_type=${package_content_type}" >> "${GITHUB_OUTPUT}"
 echo "package_content_type=${package_content_type}" >> $GITHUB_ENV
 
 # As is common input tag
-echo "::set-output name=package_tag::${INPUT_TAG}"
+echo "package_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
 echo "package_tag=${INPUT_TAG}" >> $GITHUB_ENV
 
 # Keep lists of package names, tagged, names
@@ -78,7 +78,7 @@ for spack_package in $(find ${BUILD_CACHE} -name *.spack); do
     fi
 done
 
-echo "::set-output name=package_name::${package_names}"
-echo "::set-output name=package_tagged_names::${tagged_names}"
+echo "package_name=${package_names}" >> "${GITHUB_OUTPUT}"
+echo "package_tagged_names=${tagged_names}" >> "${GITHUB_OUTPUT}"
 echo "package_names=${package_names}" >> $GITHUB_ENV
 echo "package_tagged_names=${tagged_names}" >> $GITHUB_ENV

--- a/package/scripts/build.sh
+++ b/package/scripts/build.sh
@@ -108,8 +108,8 @@ tree ${build_cache}
 # We want to save the .json files for any following step :)
 spec_jsons=""
 
-echo "::set-output name=build_cache::${build_cache}"
-echo "::set-output name=build_cache_prefix::${build_cache_prefix}"
+echo "build_cache=${build_cache}" >> "${GITHUB_OUTPUT}"
+echo "build_cache_prefix=${build_cache_prefix}" >> "${GITHUB_OUTPUT}"
 
 # There can be more than one thing in the build cache
 for spec_json in $(find ${build_cache} -name *.json); do
@@ -123,8 +123,8 @@ for spec_json in $(find ${build_cache} -name *.json); do
 done
 
 # Set output for spec, and TODO binary to upload/save for next step
-echo "::set-output name=spec::${SPACK_SPEC}"
-echo "::set-output name=spec_jsons::${spec_jsons}"
+echo "spec=${SPACK_SPEC}" >> "${GITHUB_OUTPUT}"
+echo "spec_jsons=${spec_jsons}" >> "${GITHUB_OUTPUT}"
 echo "spec=${SPACK_SPEC}" >> $GITHUB_ENV
 echo "spec_jsons=${spec_jsons}" >> $GITHUB_ENV
 echo "build_cache=${build_cache}" >> $GITHUB_ENV

--- a/package/scripts/release.sh
+++ b/package/scripts/release.sh
@@ -34,11 +34,11 @@ fi
 
 # Package content type is always consistent
 package_content_type=application/vnd.spack.package
-echo "::set-output name=package_content_type::${package_content_type}"
+echo "package_content_type=${package_content_type}" >> "${GITHUB_OUTPUT}"
 echo "package_content_type=${package_content_type}" >> $GITHUB_ENV
 
 # As is common input tag
-echo "::set-output name=package_tag::${INPUT_TAG}"
+echo "package_tag=${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
 echo "package_tag=${INPUT_TAG}" >> $GITHUB_ENV
 
 # Keep lists of package names, tagged, names
@@ -78,7 +78,7 @@ for spack_package in $(find ${BUILD_CACHE} -name *.spack); do
     fi
 done
 
-echo "::set-output name=package_name::${package_names}"
-echo "::set-output name=package_tagged_names::${tagged_names}"
+echo "package_name=${package_names}" >> "${GITHUB_OUTPUT}"
+echo "package_tagged_names=${tagged_names}" >> "${GITHUB_OUTPUT}"
 echo "package_names=${package_names}" >> $GITHUB_ENV
 echo "package_tagged_names=${tagged_names}" >> $GITHUB_ENV


### PR DESCRIPTION
For reference, see <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>.